### PR TITLE
docs: add AGENTS.md; tests: align with stored JSON wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root script: `brew_parser.py` (CLI entrypoint and core logic)
+- Tests: `test_brew_parser.py` (pytest)
+- Config: `pyproject.toml` (mypy, black, pytest), `requirements*.txt`
+- Data/assets: `formula.json` (sample data), cache dirs like `.pytest_cache/`, `.mypy_cache/`
+- Virtual env (local): `venv/` (do not commit)
+
+## Build, Test, and Development Commands
+- Setup venv: `python3 -m venv venv && source venv/bin/activate`
+- Install deps: `pip install -r requirements.txt` (add `-r requirements-dev.txt` for dev)
+- Run CLI: `python brew_parser.py [update|diff|new|--limit N]`
+- Test (quiet): `pytest` or `pytest -q`
+- Coverage: `pytest --cov=brew_parser` (optional)
+- Format: `black brew_parser.py test_brew_parser.py`
+- Lint: `flake8 brew_parser.py test_brew_parser.py --max-line-length=88`
+- Type-check: `mypy brew_parser.py --strict`
+
+## Coding Style & Naming Conventions
+- Python 3.8+; 4-space indentation; max line length 88 (black/pylint)
+- Use type hints everywhere (project runs mypy in strict mode)
+- Naming: modules/functions `snake_case`, classes `CapWords`, constants `UPPER_SNAKE`
+- Prefer small, pure functions; handle network/file I/O errors explicitly
+- Keep user-visible CLI output stable; update tests if output format changes
+
+## Testing Guidelines
+- Framework: pytest (configured via `pyproject.toml` with `-ra -q --strict-markers`)
+- Tests live in `test_brew_parser.py`; add new tests as `test_*.py` if needed
+- Write tests for parsing, change-diff logic, and error paths
+- Aim for meaningful coverage on core behaviors; use `pytest --cov` locally
+
+## Commit & Pull Request Guidelines
+- Commits: imperative mood, concise, scoped (e.g., "Add diff table rendering")
+- Reference issues in the body when applicable (e.g., "Fixes #12")
+- PRs: include a clear description, rationale, sample CLI output (before/after), and steps to test
+- Keep diffs focused; include screenshots or text snippets of CLI tables when helpful
+
+## Security & Configuration Tips
+- Never commit secrets; this tool only uses public Homebrew data
+- Local data is stored under `~/.brew-parser/` (e.g., `formulas.json`, `metadata.json`)
+- Use a venv on macOS (PEP 668) to avoid "externally-managed-environment" errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-09-13
+
+### Added
+- AGENTS.md contributor guide with structure, commands, style, and PR tips
+
+### Fixed
+- Tests aligned with stored JSON wrapper format ({"formulas": [...]})
+- No functional changes; documentation and test expectations only
+
 ## [0.2.0] - 2025-09-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brew-parser"
-version = "0.2.0"
+version = "0.2.1"
 description = "Track changes in Homebrew formulas - see what's new, updated, or removed"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/test_brew_parser.py
+++ b/test_brew_parser.py
@@ -275,10 +275,10 @@ class TestBrewParser:
         assert parser.stored_formulas_path.exists()
         assert parser.metadata_path.exists()
 
-        # Verify content
+        # Verify content (wrapped format {"formulas": [...]})
         with open(parser.stored_formulas_path) as f:
             stored_data = json.load(f)
-        assert stored_data == mock_formulas
+        assert stored_data["formulas"] == mock_formulas
 
         # Verify metadata
         with open(parser.metadata_path) as f:
@@ -295,10 +295,10 @@ class TestBrewParser:
         parser.stored_formulas_path = tmp_path / "formulas.json"
         parser.metadata_path = tmp_path / "metadata.json"
 
-        # Create existing data
+        # Create existing data (wrapped format {"formulas": [...]})
         existing_data = [{"name": "tool1", "desc": "Tool 1"}]
         with open(parser.stored_formulas_path, "w") as f:
-            json.dump(existing_data, f, indent=2)
+            json.dump({"formulas": existing_data}, f, indent=2)
 
         # Mock same data from API
         mock_fetch.return_value = existing_data


### PR DESCRIPTION
Summary
- Add AGENTS.md with concise contributor guidelines specific to brew-parser
- Update tests to match stored JSON wrapper format {"formulas": [...]} to reflect implementation and README

Validation
- black, flake8, mypy --strict all pass
- pytest: all tests pass

Notes
- No runtime logic changes; only docs + test expectations
- Keeps output formatting stable; improves contributor onboarding